### PR TITLE
Adds bootstrap step to development doc.

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -10,6 +10,7 @@ To install, run:
 git clone git@github.com:crcn/tandem.git;
 cd tandem;
 yarn install;
+npm run bootstrap;
 ```
 
 Then run:


### PR DESCRIPTION
Rather small, but it took me a bit to figure out what lerna does and that the `bootstrap` command was needed to run the builds.

As a side note:  Why are you using yarn for the install and npm to run scripts?  It seems to work just fine.  I'm just curious.